### PR TITLE
#43 - Session tags are now sent to the remote server as JSON

### DIFF
--- a/pytest_monitor/session.py
+++ b/pytest_monitor/session.py
@@ -90,7 +90,7 @@ class PyTestMonitorSession(object):
                               json=dict(session_h=self.__session,
                                         run_date=run_date,
                                         scm_ref=scm,
-                                        description=description))
+                                        description=json.loads(description)))
             if r.status_code != HTTPStatus.CREATED:
                 self.__remote = ''
                 msg = "Cannot insert session in remote monitor server ({})! Deactivating...')".format(r.status_code)


### PR DESCRIPTION
# Description

Session tags are sent as text to the remote server. The problem is that the monitor-server provided in the monitor-server-api package expects them to be sent as JSON value (dict). The fix consists in sending session tags as JSON.

Fixes #43

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

If an option is not relevant to your PR, do not delete it but use ~strikethrough formating on it~. This helps keeping track of the entire list.

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (not just the [CI](https://link.to.ci))
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have provided a link to the issue this PR adresses in the Description section above (If there is none yet,
[create one](https://github.com/CFMTech/pytest-monitor/issues) !)
- [ ] I have updated the [changelog](https://github.com/CFMTech/pytest-monitor/blob/master/docs/sources/changelog.rst)
- [ ] I have labeled my PR using appropriate tags (in particular using status labels like [`Status: Code Review Needed`](https://github.com/jsd-spif/pymonitor/labels/Status%3A%20Code%20Review%20Needed), [`Business: Test Needed`](https://github.com/jsd-spif/pymonitor/labels/Business%3A%20Test%20Needed) or [`Status: In Progress`](https://github.com/jsd-spif/pymonitor/labels/Status%3A%20In%20Progress) if you are still working on the PR)

Do not forget to @ the people that needs to do the review

Thanks for contributing! :pray:
